### PR TITLE
🚀 Grant user User Access Administrator role on subscription level

### DIFF
--- a/provisioning/gh-aad.ps1
+++ b/provisioning/gh-aad.ps1
@@ -29,9 +29,10 @@ function Execute-AAD
         $AzureCredentials = ConvertFrom-Json $AzureCredentialsJson
     
         az login --allow-no-subscriptions --service-principal -u $($AzureCredentials.clientId) -p $($AzureCredentials.clientSecret) --tenant $($AzureCredentials.tenantId)
+        $account = az account show | ConvertFrom-Json
         $userObject = CreateAADUser -githubHandle $githubHandle -InitialPassword $InitialPassword
         AddADUserToResourceGroup -ResourceGroup "rg-$($githubHandle)" -AADUserId $($userObject.id) -role "Owner"
-
+        az role assignment create --assignee-object-id $($userObject.id) --role "User Access Administrator" --scope /subscriptions/$($account.id)
     }    
 
 


### PR DESCRIPTION
This grants the new user "User Access Administrator" role on subscription level, so that they can also issue new Service Principals with `az ad sp create-for-rbac ...`